### PR TITLE
OSGi metadata and fragments

### DIFF
--- a/neo4j-ogm-api-osgi.bnd
+++ b/neo4j-ogm-api-osgi.bnd
@@ -1,0 +1,7 @@
+package-version=${version;===;${Bundle-Version}}
+
+Export-Package: \
+ *;version="${package-version}"
+
+Import-Package: \
+ *

--- a/neo4j-ogm-bolt-driver-osgi.bnd
+++ b/neo4j-ogm-bolt-driver-osgi.bnd
@@ -1,0 +1,10 @@
+package-version=${version;===;${Bundle-Version}}
+
+Export-Package: \
+ *;version="${package-version}"
+
+Import-Package: \
+ *
+
+Fragment-Host: \
+ org.neo4j.ogm-core

--- a/neo4j-ogm-bolt-native-types-osgi.bnd
+++ b/neo4j-ogm-bolt-native-types-osgi.bnd
@@ -1,0 +1,7 @@
+package-version=${version;===;${Bundle-Version}}
+
+Export-Package: \
+ *;version="${package-version}"
+
+Import-Package: \
+ *

--- a/neo4j-ogm-core-osgi.bnd
+++ b/neo4j-ogm-core-osgi.bnd
@@ -1,0 +1,7 @@
+package-version=${version;===;${Bundle-Version}}
+
+Export-Package: \
+ *;version="${package-version}"
+
+Import-Package: \
+ *

--- a/neo4j-ogm-embedded-driver-osgi.bnd
+++ b/neo4j-ogm-embedded-driver-osgi.bnd
@@ -1,0 +1,7 @@
+package-version=${version;===;${Bundle-Version}}
+
+Export-Package: \
+ *;version="${package-version}"
+
+Import-Package: \
+ *

--- a/neo4j-ogm-embedded-native-types-osgi.bnd
+++ b/neo4j-ogm-embedded-native-types-osgi.bnd
@@ -1,0 +1,7 @@
+package-version=${version;===;${Bundle-Version}}
+
+Export-Package: \
+ *;version="${package-version}"
+
+Import-Package: \
+ *

--- a/neo4j-ogm-http-driver-osgi.bnd
+++ b/neo4j-ogm-http-driver-osgi.bnd
@@ -1,0 +1,10 @@
+package-version=${version;===;${Bundle-Version}}
+
+Export-Package: \
+ *;version="${package-version}"
+
+Import-Package: \
+ *
+
+Fragment-Host: \
+ org.neo4j.ogm-core

--- a/neo4j-ogm-integration-tests-osgi.bnd
+++ b/neo4j-ogm-integration-tests-osgi.bnd
@@ -1,0 +1,7 @@
+package-version=${version;===;${Bundle-Version}}
+
+Export-Package: \
+ *;version="${package-version}"
+
+Import-Package: \
+ *

--- a/neo4j-ogm-native-types-tests-osgi.bnd
+++ b/neo4j-ogm-native-types-tests-osgi.bnd
@@ -1,0 +1,7 @@
+package-version=${version;===;${Bundle-Version}}
+
+Export-Package: \
+ *;version="${package-version}"
+
+Import-Package: \
+ *

--- a/neo4j-ogm-tests-report-osgi.bnd
+++ b/neo4j-ogm-tests-report-osgi.bnd
@@ -1,0 +1,7 @@
+package-version=${version;===;${Bundle-Version}}
+
+Export-Package: \
+ *;version="${package-version}"
+
+Import-Package: \
+ *

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,8 @@
 
         <maven-jar-plugin.version>3.0.1</maven-jar-plugin.version>
         <maven-bundle-plugin.version>4.2.1</maven-bundle-plugin.version>
+
+        <rootDir>${session.executionRootDirectory}</rootDir>
     </properties>
 
     <distributionManagement>
@@ -53,11 +55,9 @@
                         <supportedProjectTypes>
                             <supportedProjectTypes>jar</supportedProjectTypes>
                         </supportedProjectTypes>
-                        <!--
                         <instructions>
-                            <_include>../../${project.artifactId}-osgi.bnd</_include>
+                            <_include>${rootDir}/${project.artifactId}-osgi.bnd</_include>
                         </instructions>
-                        -->
                     </configuration>
                     <executions>
                         <execution>


### PR DESCRIPTION
Integrate OSGi bundle descriptors as bnd resource files. Maven bundle plugin gets executed for any maven module which exhibits a jar-based packaging in the neo4j-ogm project.

Bundle relationship

The bundle ogm-core represents the Fragment-Host.

The bundles bolt-driver and http-driver are of type Fragment-Bundle, which reference ogm-core as their Fragment-Host.

Fix reference to bnd resource descriptor files

Instead of referencing a -osgi-bnd resource file from a child through a relative path, a property which maven exposes (session execution root directory) gets used.

For the future, a more robust solution has to gets required to disable bundling in the build phase for integration tests. Maven profiles might help explicitly listing those modules which require bundling.