### PR TITLE
Fix Gitlab repository authentication

### DIFF
--- a/settings.xml
+++ b/settings.xml
@@ -8,8 +8,8 @@
             <configuration>
                 <httpHeaders>
                     <property>
-                        <name>Job-Token</name>
-                        <value>${env.CI_JOB_TOKEN}</value>
+                        <name>Private-Token</name>
+                        <value>${env.GITLAB_PRIVATE_TOKEN}</value>
                     </property>
                 </httpHeaders>
             </configuration>


### PR DESCRIPTION
It seems using Gitlabs CI_JOB_TOKEN to access outside repositories such as the repository hosting the custom neo4j java driver build is not successful. Using CI_JOB_TOKEN can not access the repo of the project 18622687. To change this limitation, a user's private token gets used in the server setup. Generating the token Gitlabs asks various capabilities, including writing and reading repositories in the user scope.