### PR TITLE
Differentiate Gitlab repository ids

### DIFF
--- a/settings.xml
+++ b/settings.xml
@@ -8,6 +8,17 @@
             <configuration>
                 <httpHeaders>
                     <property>
+                        <name>Job-Token</name>
+                        <value>${env.CI_JOB_TOKEN}</value>
+                    </property>
+                </httpHeaders>
+            </configuration>
+        </server>
+        <server>
+            <id>gitlab-all</id>
+            <configuration>
+                <httpHeaders>
+                    <property>
                         <name>Private-Token</name>
                         <value>${env.GITLAB_PRIVATE_TOKEN}</value>
                     </property>
@@ -30,7 +41,7 @@
             <repositories>
                 <!-- Neo4j Java Driver - custom build dependency hosted at Gitlab maven registry -->
                 <repository>
-                    <id>gitlab-maven</id>
+                    <id>gitlab-all</id>
                     <url>https://gitlab.com/api/v4/projects/18622687/packages/maven</url>
                     <releases>
                         <enabled>true</enabled>


### PR DESCRIPTION
Use gitlab-maven for deployment purposes. Here the env.CI_JOB_TOKEN gets used.
Use gitlab-all for repository access. Here the env.GITLAB_PRIVATE_TOKEN of the user gets used.