### PR TITLE
No fragment bundles

### DIFF
--- a/bnd/neo4j-ogm-bolt-driver.bnd
+++ b/bnd/neo4j-ogm-bolt-driver.bnd
@@ -5,6 +5,3 @@ Export-Package: \
 
 Import-Package: \
  *
-
-Fragment-Host: \
- org.neo4j.ogm-core

--- a/bnd/neo4j-ogm-http-driver.bnd
+++ b/bnd/neo4j-ogm-http-driver.bnd
@@ -5,6 +5,3 @@ Export-Package: \
 
 Import-Package: \
  *
-
-Fragment-Host: \
- org.neo4j.ogm-core

--- a/neo4j-ogm-feature/neo4j-ogm-api-feature/pom.xml
+++ b/neo4j-ogm-feature/neo4j-ogm-api-feature/pom.xml
@@ -25,7 +25,7 @@
         <groupId>org.neo4j</groupId>
         <artifactId>neo4j-ogm-feature</artifactId>
         <version>4.0.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>neo4j-ogm-api-feature</artifactId>
@@ -34,15 +34,11 @@
 
     <name>Neo4j OGM - API Feature</name>
 
-    <properties>
-        <version.karaf-maven-plugin>4.3.0.RC1</version.karaf-maven-plugin>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.neo4j</groupId>
             <artifactId>neo4j-ogm-api</artifactId>
-            <version>${project.version}</version>
+            <version>${neo4j-ogm.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>

--- a/neo4j-ogm-feature/neo4j-ogm-bolt-driver-feature/pom.xml
+++ b/neo4j-ogm-feature/neo4j-ogm-bolt-driver-feature/pom.xml
@@ -25,7 +25,7 @@
         <groupId>org.neo4j</groupId>
         <artifactId>neo4j-ogm-feature</artifactId>
         <version>4.0.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>neo4j-ogm-bolt-driver-feature</artifactId>
@@ -33,11 +33,6 @@
     <packaging>feature</packaging>
 
     <name>Neo4j OGM - Bolt Driver Feature</name>
-
-    <properties>
-        <version.karaf-maven-plugin>4.3.0.RC1</version.karaf-maven-plugin>
-        <neo4j-java-driver-feature.version>4.0-SNAPSHOT</neo4j-java-driver-feature.version>
-    </properties>
 
     <repositories>
         <repository>
@@ -71,7 +66,7 @@
         <dependency>
             <groupId>org.neo4j</groupId>
             <artifactId>neo4j-ogm-core-feature</artifactId>
-            <version>${project.version}</version>
+            <version>${neo4j-ogm.version}</version>
             <type>xml</type>
             <classifier>features</classifier>
         </dependency>
@@ -79,7 +74,7 @@
         <dependency>
             <groupId>org.neo4j</groupId>
             <artifactId>neo4j-ogm-bolt-driver</artifactId>
-            <version>${project.version}</version>
+            <version>${neo4j-ogm.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.neo4j.driver</groupId>

--- a/neo4j-ogm-feature/neo4j-ogm-core-feature/pom.xml
+++ b/neo4j-ogm-feature/neo4j-ogm-core-feature/pom.xml
@@ -25,7 +25,7 @@
         <groupId>org.neo4j</groupId>
         <artifactId>neo4j-ogm-feature</artifactId>
         <version>4.0.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>neo4j-ogm-core-feature</artifactId>
@@ -34,16 +34,12 @@
 
     <name>Neo4j OGM - Core Feature</name>
 
-    <properties>
-        <version.karaf-maven-plugin>4.3.0.RC1</version.karaf-maven-plugin>
-    </properties>
-
     <dependencies>
 
         <dependency>
             <groupId>org.neo4j</groupId>
             <artifactId>neo4j-ogm-api-feature</artifactId>
-            <version>${project.version}</version>
+            <version>${neo4j-ogm.version}</version>
             <type>xml</type>
             <classifier>features</classifier>
         </dependency>
@@ -51,7 +47,7 @@
         <dependency>
             <groupId>org.neo4j</groupId>
             <artifactId>neo4j-ogm-core</artifactId>
-            <version>${project.version}</version>
+            <version>${neo4j-ogm.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.neo4j</groupId>

--- a/neo4j-ogm-feature/pom.xml
+++ b/neo4j-ogm-feature/pom.xml
@@ -27,6 +27,7 @@
     </parent>
 
     <artifactId>neo4j-ogm-feature</artifactId>
+    <version>4.0.0-SNAPSHOT</version>
 
     <packaging>pom</packaging>
 
@@ -40,6 +41,10 @@
         <maven-install-plugin.version>2.5.2</maven-install-plugin.version>
         <!-- Override version for maven-deploy-plugin due to a bug similar to the maven-install-plugin -->
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
+
+        <neo4j-ogm.version>4.0.0-SNAPSHOT</neo4j-ogm.version>
+        <neo4j-java-driver-feature.version>4.0-SNAPSHOT</neo4j-java-driver-feature.version>
+
     </properties>
 
     <build>


### PR DESCRIPTION
An assumption made in advance states that fragment bundles are assumed. Tests show that this instrument is not required for bolt or http driver transport.

Maven properties

Cleanup maven properties in feature modules, handle props in parent module. Introduce property neo4j-ogm.version to reflect which version the neo4j-ogm as a git submodule has.