### PR TITLE
Re-Introduce-OSGi-Fragments

### DIFF
--- a/bnd/neo4j-ogm-bolt-driver.bnd
+++ b/bnd/neo4j-ogm-bolt-driver.bnd
@@ -5,3 +5,6 @@ Export-Package: \
 
 Import-Package: \
  *
+
+Fragment-Host: \
+ org.neo4j.ogm-core

--- a/bnd/neo4j-ogm-http-driver.bnd
+++ b/bnd/neo4j-ogm-http-driver.bnd
@@ -5,3 +5,6 @@ Export-Package: \
 
 Import-Package: \
  *
+
+Fragment-Host: \
+ org.neo4j.ogm-core


### PR DESCRIPTION
The instrument "Fragments" for the Bolt or Http-driver transport is not needed in the OSGi runtime Equinox; but in Apache Felix.