### PR TITLE
Extend feature builds for other drivers

### DIFF
--- a/bnd/neo4j-ogm-embedded-driver.bnd
+++ b/bnd/neo4j-ogm-embedded-driver.bnd
@@ -5,3 +5,6 @@ Export-Package: \
 
 Import-Package: \
  *
+
+Fragment-Host: \
+ org.neo4j.ogm-core

--- a/neo4j-ogm-feature/neo4j-ogm-embedded-driver-feature/pom.xml
+++ b/neo4j-ogm-feature/neo4j-ogm-embedded-driver-feature/pom.xml
@@ -28,39 +28,23 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>neo4j-ogm-bolt-driver-feature</artifactId>
+    <artifactId>neo4j-ogm-embedded-driver-feature</artifactId>
 
     <packaging>feature</packaging>
 
-    <name>Neo4j OGM - Bolt Driver Feature</name>
-
-    <repositories>
-        <repository>
-            <id>gitlab-maven</id>
-            <url>https://gitlab.com/api/v4/projects/18622687/packages/maven</url>
-        </repository>
-    </repositories>
+    <name>Neo4j OGM - Embedded Driver Feature</name>
 
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>org.neo4j</groupId>
-                <artifactId>neo4j-ogm-bolt-driver</artifactId>
+                <artifactId>neo4j-ogm-embedded-driver</artifactId>
                 <version>${neo4j-ogm.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
 
     <dependencies>
-
-        <dependency>
-            <groupId>org.neo4j.driver</groupId>
-            <artifactId>neo4j-java-driver-feature</artifactId>
-            <version>${neo4j-java-driver-feature.version}</version>
-            <type>xml</type>
-            <classifier>features</classifier>
-        </dependency>
-
         <dependency>
             <groupId>org.neo4j</groupId>
             <artifactId>neo4j-ogm-core-feature</artifactId>
@@ -68,14 +52,17 @@
             <type>xml</type>
             <classifier>features</classifier>
         </dependency>
-
         <dependency>
             <groupId>org.neo4j</groupId>
-            <artifactId>neo4j-ogm-bolt-driver</artifactId>
+            <artifactId>neo4j-ogm-embedded-driver</artifactId>
             <exclusions>
                 <exclusion>
-                    <groupId>org.neo4j.driver</groupId>
-                    <artifactId>neo4j-java-driver</artifactId>
+                    <groupId>org.neo4j</groupId>
+                    <artifactId>neo4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.neo4j.app</groupId>
+                    <artifactId>neo4j-server</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.neo4j</groupId>
@@ -87,7 +74,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
     </dependencies>
 
 </project>

--- a/neo4j-ogm-feature/neo4j-ogm-embedded-driver-feature/src/main/feature/feature.xml
+++ b/neo4j-ogm-feature/neo4j-ogm-embedded-driver-feature/src/main/feature/feature.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<features name="${project.artifactId}-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.0.0">
+
+    <feature name='${project.artifactId}' description='${project.name}' version='${project.version}'>
+        <details>${project.description}</details>
+    </feature>
+
+</features>

--- a/neo4j-ogm-feature/neo4j-ogm-http-driver-feature/pom.xml
+++ b/neo4j-ogm-feature/neo4j-ogm-http-driver-feature/pom.xml
@@ -28,39 +28,23 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>neo4j-ogm-bolt-driver-feature</artifactId>
+    <artifactId>neo4j-ogm-http-driver-feature</artifactId>
 
     <packaging>feature</packaging>
 
-    <name>Neo4j OGM - Bolt Driver Feature</name>
-
-    <repositories>
-        <repository>
-            <id>gitlab-maven</id>
-            <url>https://gitlab.com/api/v4/projects/18622687/packages/maven</url>
-        </repository>
-    </repositories>
+    <name>Neo4j OGM - Http Driver Feature</name>
 
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>org.neo4j</groupId>
-                <artifactId>neo4j-ogm-bolt-driver</artifactId>
+                <artifactId>neo4j-ogm-http-driver</artifactId>
                 <version>${neo4j-ogm.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
 
     <dependencies>
-
-        <dependency>
-            <groupId>org.neo4j.driver</groupId>
-            <artifactId>neo4j-java-driver-feature</artifactId>
-            <version>${neo4j-java-driver-feature.version}</version>
-            <type>xml</type>
-            <classifier>features</classifier>
-        </dependency>
-
         <dependency>
             <groupId>org.neo4j</groupId>
             <artifactId>neo4j-ogm-core-feature</artifactId>
@@ -68,15 +52,10 @@
             <type>xml</type>
             <classifier>features</classifier>
         </dependency>
-
         <dependency>
             <groupId>org.neo4j</groupId>
-            <artifactId>neo4j-ogm-bolt-driver</artifactId>
+            <artifactId>neo4j-ogm-http-driver</artifactId>
             <exclusions>
-                <exclusion>
-                    <groupId>org.neo4j.driver</groupId>
-                    <artifactId>neo4j-java-driver</artifactId>
-                </exclusion>
                 <exclusion>
                     <groupId>org.neo4j</groupId>
                     <artifactId>neo4j-ogm-api</artifactId>
@@ -87,7 +66,5 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
     </dependencies>
-
 </project>

--- a/neo4j-ogm-feature/neo4j-ogm-http-driver-feature/src/main/feature/feature.xml
+++ b/neo4j-ogm-feature/neo4j-ogm-http-driver-feature/src/main/feature/feature.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<features name="${project.artifactId}-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.0.0">
+
+    <feature name='${project.artifactId}' description='${project.name}' version='${project.version}'>
+        <details>${project.description}</details>
+    </feature>
+
+</features>

--- a/neo4j-ogm-feature/pom.xml
+++ b/neo4j-ogm-feature/pom.xml
@@ -91,6 +91,8 @@
     <modules>
         <module>neo4j-ogm-api-feature</module>
         <module>neo4j-ogm-core-feature</module>
+        <module>neo4j-ogm-embedded-driver-feature</module>
+        <module>neo4j-ogm-http-driver-feature</module>
         <module>neo4j-ogm-bolt-driver-feature</module>
     </modules>
 


### PR DESCRIPTION
Generate further deployment features for the http and embedded driver modules.

Avoid duplicated dependencies in driver features

Exclude OGM`s API and Core module dependencies from being pulled in the driver features.