### PR TITLE
Simplify build

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The pom file of the original project will result
 > Requirement: Docker installation on the build system
 
 ```
-mvn clean install
+mvn -s settings.xml clean install
 ```
 
 #### Minified build - excluding tests, and docs
@@ -55,7 +55,7 @@ mvn clean install
 > Without a docker installation
 
 ```
-mvn clean install -Dmaven.test.skip=true -Dmaven.javadoc.skip=true
+mvn -s settings.xml clean install -Dmaven.test.skip=true -Dmaven.javadoc.skip=true
 ```
 
 ## Using artifacts

--- a/pom-modify.xml
+++ b/pom-modify.xml
@@ -12,22 +12,13 @@
     <packaging>pom</packaging>
 
     <properties>
-        <gitlab.repo.id>placeholder-gitlab.repo.id</gitlab.repo.id>
-        <gitlab.repo.url>placeholder-gitlab.repo.url</gitlab.repo.url>
-
         <pomutils-maven-plugin.version>1.1.0</pomutils-maven-plugin.version>
+
         <pomFile-to-alter>neo4j-ogm/pom.xml</pomFile-to-alter>
         <relativePath-parent>../</relativePath-parent>
 
         <neo4j-java-driver-modifier.version>4.0-SNAPSHOT</neo4j-java-driver-modifier.version>
     </properties>
-
-    <pluginRepositories>
-        <pluginRepository>
-            <id>${gitlab.repo.id}</id>
-            <url>${gitlab.repo.url}</url>
-        </pluginRepository>
-    </pluginRepositories>
 
     <build>
         <pluginManagement>

--- a/settings-modify.xml
+++ b/settings-modify.xml
@@ -1,19 +1,23 @@
-<settings xmlns="http://maven.apache.org/settings/1.0.0"
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
 
     <profiles>
         <profile>
             <id>gitlab-build</id>
-
-            <!-- Properties reference the POM utils maven plugin. The plugin is a custom hosted at Gitlab -->
-
-            <properties>
-                <gitlab.project.id>18580785</gitlab.project.id>
-                <gitlab.repo.id>gitlab-maven</gitlab.repo.id>
-                <gitlab.repo.url>https://gitlab.com/api/v4/projects/${gitlab.project.id}/packages/maven
-                </gitlab.repo.url>
-            </properties>
+            <pluginRepositories>
+                <!-- POM Utils - custom build dependency hosted at Gitlab maven registry -->
+                <pluginRepository>
+                    <id>gitlab-maven</id>
+                    <url>https://gitlab.com/api/v4/projects/18580785/packages/maven</url>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                </pluginRepository>
+            </pluginRepositories>
         </profile>
     </profiles>
 

--- a/settings.xml
+++ b/settings.xml
@@ -1,4 +1,4 @@
-<settings xmlns="http://maven.apache.org/settings/1.0.0"
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
 
@@ -43,7 +43,7 @@
                      repository {env.CI_PROJECT_ID} where the current artifacts get hosted -->
                 <repository>
                     <id>gitlab-maven</id>
-                    <url>https://gitlab.com/api/v4/projects/${env.CI_PROJECT_ID}/packages/maven</url>
+                    <url>https://gitlab.com/api/v4/projects/18591736/packages/maven</url>
                     <releases>
                         <enabled>true</enabled>
                     </releases>


### PR DESCRIPTION
Move plugin repository configuration into settings-modify.xml, remove unused variables.

Improve build instructions

A local settings.xml file is required because it is providing relevant information such as the repository configuration.