### PR TITLE
Add dedicated Neo4j OGM OSGi module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
+**/*.iml
 target

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The pom file of the original project will result
 ...
   <parent>
     <groupId>org.neo4j</groupId>
-    <artifactId>neo4j-ogm-osgi</artifactId>
+    <artifactId>neo4j-ogm-osgi-parent</artifactId>
     <version>4.0.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>

--- a/neo4j-ogm-feature/neo4j-ogm-bolt-driver-feature/pom.xml
+++ b/neo4j-ogm-feature/neo4j-ogm-bolt-driver-feature/pom.xml
@@ -63,7 +63,7 @@
 
         <dependency>
             <groupId>org.neo4j</groupId>
-            <artifactId>neo4j-ogm-core-feature</artifactId>
+            <artifactId>neo4j-ogm-api-feature</artifactId>
             <version>${neo4j-ogm.version}</version>
             <type>xml</type>
             <classifier>features</classifier>
@@ -82,8 +82,8 @@
                     <artifactId>neo4j-ogm-api</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>org.neo4j</groupId>
-                    <artifactId>neo4j-ogm-core</artifactId>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/neo4j-ogm-feature/neo4j-ogm-osgi-feature/pom.xml
+++ b/neo4j-ogm-feature/neo4j-ogm-osgi-feature/pom.xml
@@ -28,36 +28,18 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>neo4j-ogm-core-feature</artifactId>
+    <artifactId>neo4j-ogm-osgi-feature</artifactId>
 
     <packaging>feature</packaging>
 
-    <name>Neo4j OGM - Core Feature</name>
+    <name>Neo4j OGM - API Feature</name>
 
     <dependencies>
-
         <dependency>
             <groupId>org.neo4j</groupId>
-            <artifactId>neo4j-ogm-api-feature</artifactId>
+            <artifactId>neo4j-ogm-osgi</artifactId>
             <version>${neo4j-ogm.version}</version>
-            <type>xml</type>
-            <classifier>features</classifier>
-        </dependency>
-
-        <dependency>
-            <groupId>org.neo4j</groupId>
-            <artifactId>neo4j-ogm-core</artifactId>
-            <version>${neo4j-ogm.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.neo4j</groupId>
-                    <artifactId>neo4j-ogm-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
     </dependencies>
+
 </project>

--- a/neo4j-ogm-feature/neo4j-ogm-osgi-feature/src/main/feature/feature.xml
+++ b/neo4j-ogm-feature/neo4j-ogm-osgi-feature/src/main/feature/feature.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<features name="${project.artifactId}-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.0.0">
+
+    <feature name='${project.artifactId}' description='${project.name}' version='${project.version}'>
+        <details>${project.description}</details>
+    </feature>
+
+</features>

--- a/neo4j-ogm-feature/pom.xml
+++ b/neo4j-ogm-feature/pom.xml
@@ -21,7 +21,7 @@
 
     <parent>
         <groupId>org.neo4j</groupId>
-        <artifactId>neo4j-ogm-osgi</artifactId>
+        <artifactId>neo4j-ogm-osgi-parent</artifactId>
         <version>4.0.0-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
@@ -64,8 +64,8 @@
                     <version>${karaf-maven-plugin.version}</version>
                     <extensions>true</extensions>
                     <configuration>
-                        <startLevel>80</startLevel>
-                        <aggregateFeatures>true</aggregateFeatures>
+                        <startLevel>70</startLevel>
+                        <aggregateFeatures>false</aggregateFeatures>
                         <enableGeneration>true</enableGeneration>
                     </configuration>
                     <executions>
@@ -94,6 +94,7 @@
         <module>neo4j-ogm-embedded-driver-feature</module>
         <module>neo4j-ogm-http-driver-feature</module>
         <module>neo4j-ogm-bolt-driver-feature</module>
+        <module>neo4j-ogm-osgi-feature</module>
     </modules>
 
 </project>

--- a/neo4j-ogm-osgi/osgi.bnd
+++ b/neo4j-ogm-osgi/osgi.bnd
@@ -1,0 +1,3 @@
+Provide-Capability: \
+ osgi.service; \
+ objectClass:List<String>="org.osgi.service.component.ComponentFactory"

--- a/neo4j-ogm-osgi/pom.xml
+++ b/neo4j-ogm-osgi/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.neo4j</groupId>
+        <artifactId>neo4j-ogm-osgi-parent</artifactId>
+        <version>4.0.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>neo4j-ogm-osgi</artifactId>
+    <version>4.0.0-SNAPSHOT</version>
+
+    <packaging>bundle</packaging>
+
+    <name>Neo4j OGM OSGi</name>
+
+    <properties>
+        <osgi.core.version>7.0.0</osgi.core.version>
+        <osgi.cmpn.version>7.0.0</osgi.cmpn.version>
+        <neo4j-ogm.version>4.0.0-SNAPSHOT</neo4j-ogm.version>
+
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.osgi</groupId>
+                <artifactId>osgi.core</artifactId>
+                <version>${osgi.core.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.osgi</groupId>
+                <artifactId>osgi.cmpn</artifactId>
+                <version>${osgi.cmpn.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.neo4j</groupId>
+                <artifactId>neo4j-ogm-core</artifactId>
+                <version>${neo4j-ogm.version}</version>
+                <scope>provided</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>osgi.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>osgi.cmpn</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.neo4j</groupId>
+            <artifactId>neo4j-ogm-core</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <_include>osgi.bnd</_include>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/neo4j-ogm-osgi/src/main/java/org/neo4j/ogm/osgi/OGMConstants.java
+++ b/neo4j-ogm-osgi/src/main/java/org/neo4j/ogm/osgi/OGMConstants.java
@@ -1,0 +1,5 @@
+package org.neo4j.ogm.osgi;
+
+public class OGMConstants {
+  public static final String CONFIGURATION_PID = "ogm.session.component";
+}

--- a/neo4j-ogm-osgi/src/main/java/org/neo4j/ogm/osgi/OGMSessionComponent.java
+++ b/neo4j-ogm-osgi/src/main/java/org/neo4j/ogm/osgi/OGMSessionComponent.java
@@ -1,0 +1,48 @@
+package org.neo4j.ogm.osgi;
+
+import org.neo4j.ogm.config.Configuration;
+import org.neo4j.ogm.osgi.utils.classloader.ClassLoaderSwitcher;
+import org.neo4j.ogm.session.SessionFactory;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Modified;
+import org.osgi.service.metatype.annotations.Designate;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+/*
+@Designate(ocd = OGMSessionConfig.class)
+@Component(
+    service = OGMSessionComponentService.class,
+    configurationPid = OGMConstants.CONFIGURATION_PID,
+    configurationPolicy = ConfigurationPolicy.REQUIRE,
+    immediate = true)
+*/
+public class OGMSessionComponent implements OGMSessionComponentService {
+
+  private OGMSessionConfig config;
+
+  public SessionFactory getSessionFactory() throws Exception {
+
+    Configuration configuration =
+        new Configuration.Builder()
+            .uri(this.config.uri())
+            .credentials(this.config.username(), this.config.password())
+            .build();
+
+    SessionFactoryConfig sessionFactoryConfig = new SessionFactoryConfig();
+    sessionFactoryConfig.setDriverConfiguration(configuration);
+    sessionFactoryConfig.setPackages(new ArrayList<>(Arrays.asList(this.config.domain_packages())));
+
+    return ClassLoaderSwitcher.executeActionOnSpecifiedClassLoader(
+        this.getClass().getClassLoader(), new SessionFactoryAction(sessionFactoryConfig));
+  }
+
+  @Activate
+  @Modified
+  protected void activate(final OGMSessionConfig config) {
+    this.config = config;
+  }
+}

--- a/neo4j-ogm-osgi/src/main/java/org/neo4j/ogm/osgi/OGMSessionComponentService.java
+++ b/neo4j-ogm-osgi/src/main/java/org/neo4j/ogm/osgi/OGMSessionComponentService.java
@@ -1,0 +1,7 @@
+package org.neo4j.ogm.osgi;
+
+import org.neo4j.ogm.session.SessionFactory;
+
+public interface OGMSessionComponentService {
+  SessionFactory getSessionFactory() throws Exception;
+}

--- a/neo4j-ogm-osgi/src/main/java/org/neo4j/ogm/osgi/OGMSessionConfig.java
+++ b/neo4j-ogm-osgi/src/main/java/org/neo4j/ogm/osgi/OGMSessionConfig.java
@@ -1,0 +1,23 @@
+package org.neo4j.ogm.osgi;
+
+import org.osgi.service.metatype.annotations.AttributeDefinition;
+import org.osgi.service.metatype.annotations.AttributeType;
+import org.osgi.service.metatype.annotations.ObjectClassDefinition;
+
+@ObjectClassDefinition(
+    name = "OGM Session Factory Service Configuration",
+    description = "Factory Service Configurations")
+public @interface OGMSessionConfig {
+
+  @AttributeDefinition(name = "Domain Packages", type = AttributeType.STRING)
+  String[] domain_packages() default {"org.neo4j.ogm.demo.osgi.model"};
+
+  @AttributeDefinition(name = "username", type = AttributeType.STRING)
+  String username() default "neo4j";
+
+  @AttributeDefinition(name = "password", type = AttributeType.PASSWORD)
+  String password() default "neo4jPWD";
+
+  @AttributeDefinition(name = "uri", type = AttributeType.STRING)
+  String uri() default "bolt://localhost:7687";
+}

--- a/neo4j-ogm-osgi/src/main/java/org/neo4j/ogm/osgi/OGMSessionFactory.java
+++ b/neo4j-ogm-osgi/src/main/java/org/neo4j/ogm/osgi/OGMSessionFactory.java
@@ -1,0 +1,45 @@
+package org.neo4j.ogm.osgi;
+
+import org.neo4j.ogm.config.Configuration;
+import org.neo4j.ogm.osgi.utils.classloader.ClassLoaderSwitcher;
+import org.neo4j.ogm.session.SessionFactory;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Modified;
+import org.osgi.service.metatype.annotations.Designate;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+@Designate(ocd = OGMSessionConfig.class)
+@Component(
+    factory = OGMSessionFactory.FACTORY_NAME,
+    configurationPid = OGMConstants.CONFIGURATION_PID)
+public class OGMSessionFactory implements OGMSessionFactoryService {
+
+  public static final String FACTORY_NAME = "ogm.session.factory";
+
+  private OGMSessionConfig config;
+
+  public SessionFactory getSessionFactory() throws Exception {
+
+    Configuration configuration =
+        new Configuration.Builder()
+            .uri(this.config.uri())
+            .credentials(this.config.username(), this.config.password())
+            .build();
+
+    SessionFactoryConfig sessionFactoryConfig = new SessionFactoryConfig();
+    sessionFactoryConfig.setDriverConfiguration(configuration);
+    sessionFactoryConfig.setPackages(new ArrayList<>(Arrays.asList(this.config.domain_packages())));
+
+    return ClassLoaderSwitcher.executeActionOnSpecifiedClassLoader(
+        this.getClass().getClassLoader(), new SessionFactoryAction(sessionFactoryConfig));
+  }
+
+  @Activate
+  @Modified
+  protected void activate(final OGMSessionConfig config) {
+    this.config = config;
+  }
+}

--- a/neo4j-ogm-osgi/src/main/java/org/neo4j/ogm/osgi/OGMSessionFactoryService.java
+++ b/neo4j-ogm-osgi/src/main/java/org/neo4j/ogm/osgi/OGMSessionFactoryService.java
@@ -1,0 +1,7 @@
+package org.neo4j.ogm.osgi;
+
+import org.neo4j.ogm.session.SessionFactory;
+
+public interface OGMSessionFactoryService {
+  SessionFactory getSessionFactory() throws Exception;
+}

--- a/neo4j-ogm-osgi/src/main/java/org/neo4j/ogm/osgi/SessionFactoryAction.java
+++ b/neo4j-ogm-osgi/src/main/java/org/neo4j/ogm/osgi/SessionFactoryAction.java
@@ -1,0 +1,20 @@
+package org.neo4j.ogm.osgi;
+
+import org.neo4j.ogm.osgi.utils.classloader.ExecutableExceptionableAction;
+import org.neo4j.ogm.session.SessionFactory;
+
+public class SessionFactoryAction implements ExecutableExceptionableAction<SessionFactory> {
+
+  private SessionFactoryConfig config;
+
+  public SessionFactoryAction(SessionFactoryConfig config) {
+    this.config = config;
+  }
+
+  @Override
+  public SessionFactory run() throws Exception {
+    return new SessionFactory(
+        this.config.getDriverConfiguration(),
+        this.config.getPackages().stream().toArray(String[]::new));
+  }
+}

--- a/neo4j-ogm-osgi/src/main/java/org/neo4j/ogm/osgi/SessionFactoryConfig.java
+++ b/neo4j-ogm-osgi/src/main/java/org/neo4j/ogm/osgi/SessionFactoryConfig.java
@@ -1,0 +1,26 @@
+package org.neo4j.ogm.osgi;
+
+import org.neo4j.ogm.config.Configuration;
+
+import java.util.List;
+
+public class SessionFactoryConfig {
+  public Configuration driverConfiguration;
+  public List<String> packages;
+
+  public Configuration getDriverConfiguration() {
+    return driverConfiguration;
+  }
+
+  public void setDriverConfiguration(Configuration driverConfiguration) {
+    this.driverConfiguration = driverConfiguration;
+  }
+
+  public List<String> getPackages() {
+    return packages;
+  }
+
+  public void setPackages(List<String> packages) {
+    this.packages = packages;
+  }
+}

--- a/neo4j-ogm-osgi/src/main/java/org/neo4j/ogm/osgi/utils/classloader/ClassLoaderSwitcher.java
+++ b/neo4j-ogm-osgi/src/main/java/org/neo4j/ogm/osgi/utils/classloader/ClassLoaderSwitcher.java
@@ -1,0 +1,48 @@
+package org.neo4j.ogm.osgi.utils.classloader;
+
+/** Utility class for running operations on an explicitly specified class loader. */
+public class ClassLoaderSwitcher {
+  /**
+   * Execute the specified action on the provided class loader.
+   *
+   * @param classLoaderToSwitchTo Class loader from which the provided action should be executed.
+   * @param actionToPerformOnProvidedClassLoader Action to be performed on the provided class
+   *     loader.
+   * @param <T> Type of Object returned by specified action method.
+   * @return Object returned by the specified action method.
+   */
+  public static <T> T executeActionOnSpecifiedClassLoader(
+      final ClassLoader classLoaderToSwitchTo,
+      final ExecutableAction<T> actionToPerformOnProvidedClassLoader) {
+    final ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+    try {
+      Thread.currentThread().setContextClassLoader(classLoaderToSwitchTo);
+      return actionToPerformOnProvidedClassLoader.run();
+    } finally {
+      Thread.currentThread().setContextClassLoader(originalClassLoader);
+    }
+  }
+
+  /**
+   * Execute the specified action on the provided class loader.
+   *
+   * @param classLoaderToSwitchTo Class loader from which the provided action should be executed.
+   * @param actionToPerformOnProvidedClassLoader Action to be performed on the provided class
+   *     loader.
+   * @param <T> Type of Object returned by specified action method.
+   * @return Object returned by the specified action method.
+   * @throws Exception Exception that might be thrown by the specified action.
+   */
+  public static <T> T executeActionOnSpecifiedClassLoader(
+      final ClassLoader classLoaderToSwitchTo,
+      final ExecutableExceptionableAction<T> actionToPerformOnProvidedClassLoader)
+      throws Exception {
+    final ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+    try {
+      Thread.currentThread().setContextClassLoader(classLoaderToSwitchTo);
+      return actionToPerformOnProvidedClassLoader.run();
+    } finally {
+      Thread.currentThread().setContextClassLoader(originalClassLoader);
+    }
+  }
+}

--- a/neo4j-ogm-osgi/src/main/java/org/neo4j/ogm/osgi/utils/classloader/ExecutableAction.java
+++ b/neo4j-ogm-osgi/src/main/java/org/neo4j/ogm/osgi/utils/classloader/ExecutableAction.java
@@ -1,0 +1,12 @@
+package org.neo4j.ogm.osgi.utils.classloader;
+
+/** Encapsulates action to be executed. */
+public interface ExecutableAction<T> {
+  /**
+   * Execute the operation.
+   *
+   * @return Optional value returned by this operation; implementations should document what, if
+   *     anything, is returned by implementations of this method.
+   */
+  T run();
+}

--- a/neo4j-ogm-osgi/src/main/java/org/neo4j/ogm/osgi/utils/classloader/ExecutableExceptionableAction.java
+++ b/neo4j-ogm-osgi/src/main/java/org/neo4j/ogm/osgi/utils/classloader/ExecutableExceptionableAction.java
@@ -1,0 +1,13 @@
+package org.neo4j.ogm.osgi.utils.classloader;
+
+/** Describes action to be executed that is declared to throw a checked exception. */
+public interface ExecutableExceptionableAction<T> {
+  /**
+   * Execute the operation.
+   *
+   * @return Optional value returned by this operation; implementations should document what, if
+   *     anything, is returned by implementations of this method.
+   * @throws Exception that might be possibly thrown by this operation.
+   */
+  T run() throws Exception;
+}

--- a/pom-modify.xml
+++ b/pom-modify.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.neo4j</groupId>
-    <artifactId>neo4j-ogm-osgi</artifactId>
+    <artifactId>neo4j-ogm-osgi-parent</artifactId>
     <version>4.0.0-SNAPSHOT</version>
 
     <name>Neo4j OGM OSGi - Modify</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,10 +4,10 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.neo4j</groupId>
-    <artifactId>neo4j-ogm-osgi</artifactId>
+    <artifactId>neo4j-ogm-osgi-parent</artifactId>
     <version>4.0.0-SNAPSHOT</version>
 
-    <name>Neo4j OGM OSGi</name>
+    <name>Neo4j OGM OSGi Parent</name>
 
     <packaging>pom</packaging>
 
@@ -20,6 +20,7 @@
         <maven-jar-plugin.version>3.0.1</maven-jar-plugin.version>
         <maven-bundle-plugin.version>4.2.1</maven-bundle-plugin.version>
 
+        <!--suppress UnresolvedMavenProperty -->
         <rootDir>${session.executionRootDirectory}</rootDir>
     </properties>
 
@@ -54,7 +55,8 @@
                     <extensions>true</extensions>
                     <configuration>
                         <supportedProjectTypes>
-                            <supportedProjectTypes>jar</supportedProjectTypes>
+                            <supportedProjectType>jar</supportedProjectType>
+                            <supportedProjectType>bundle</supportedProjectType>
                         </supportedProjectTypes>
                         <instructions>
                             <_include>${rootDir}/bnd/${project.artifactId}.bnd</_include>
@@ -90,6 +92,7 @@
 
     <modules>
         <module>neo4j-ogm</module>
+        <module>neo4j-ogm-osgi</module>
         <module>neo4j-ogm-feature</module>
     </modules>
 

--- a/settings-modify.xml
+++ b/settings-modify.xml
@@ -6,7 +6,7 @@
         <profile>
             <id>gitlab-build</id>
             <pluginRepositories>
-                <!-- POM Utils - custom build dependency hosted at Gitlab maven registry -->
+                <!-- POM Utils - custom build dependency, hosted at Gitlab maven registry -->
                 <pluginRepository>
                     <id>gitlab-maven</id>
                     <url>https://gitlab.com/api/v4/projects/18580785/packages/maven</url>

--- a/settings.xml
+++ b/settings.xml
@@ -28,7 +28,7 @@
                 </snapshots.repo.url>
             </properties>
             <repositories>
-                <!-- Neo4j Java Driver - custom build dependency hosted at Gitlab maven registry -->
+                <!-- Neo4j Java Driver - custom build dependency, hosted at Gitlab maven registry -->
                 <repository>
                     <id>gitlab-all</id>
                     <url>https://gitlab.com/api/v4/projects/18622687/packages/maven</url>


### PR DESCRIPTION
The purpose of a dedicated module is to provide OSGi-based components, or factories for the SessionFactory Neo4j-OGM provides, a real OSGi-based application can consume.

Most important is the class-loading aspect a real application should not have to tamper with.

Both classes OGM-Session-Component and OGM-SessionFactory switch the class-loader used to generate Neo4j-OGM-SessionFactory instance, see the class Class-Loader-Switcher for more detail.

The user chooses among OGM-Session-Component or OGM-SessionFactory in its application. Examples of how to use those got illustrated in detail in the documentation, respectively, in the demo application provided.

The Session-Factories configuration is controllable in an OSGI-compatible way, more also in the documentation.

The class-loading strategy applied by Neo4j-OGM is to use the current threads context class-loader most of the time.

Thread.currentThread().getContextClassLoader()

The class-loader gets used then as a parameter for Javas API Class.forName.

This strategy is mostly not compatible with OSGi, where only the simplest version of Class.forName works 100%, of course only when clear contracts among API and implementation are guaranteed. Studying the Neo4j-OGM codebase illustrates a large room for improvements in this area.

One problem is that class loading is not optioned, meaning that environments adapted to a different class-loading strategy got not supported out of the box, and OSGi is no exception.

Testing shows that Equinox, as an OSGi runtime has somehow worked around the problem, the class loader of the current thread works out of the box with this strategy.

In an OSGi-based environment, this is just the tip of the iceberg. Handling fragment-bundles to fuse things using a single class-loader certainly complicates things here and there.

This is just a reminder when looking at the changes to determine the purpose; for more information, look at the documentation.