### PR TITLE
JDK-Downgrade

### DIFF
--- a/pom-modify.xml
+++ b/pom-modify.xml
@@ -18,7 +18,11 @@
 
         <pomFile-to-alter>neo4j-ogm/pom.xml</pomFile-to-alter>
 
-        <java-modifier.version>11</java-modifier.version>
+        <!--
+        Keep java version defined in Neo4j-OGM; otherwise, integration tests are failing
+        because of kotlin configuration (jvmTarget).
+        -->
+        <!--<java-modifier.version>11</java-modifier.version>-->
         <neo4j-java-driver-modifier.version>4.0-SNAPSHOT</neo4j-java-driver-modifier.version>
 
         <!-- Override version for maven-install-plugin due to a bug in the latest version (3.0.0-M1) preventing the
@@ -64,7 +68,9 @@
                                     </property>
                                     <property>maven-deploy-plugin.version=${maven-deploy-plugin-modifier.version}
                                     </property>
+                                    <!--
                                     <property>java.version=${java-modifier.version}</property>
+                                    -->
                                 </properties>
                             </configuration>
                         </execution>


### PR DESCRIPTION
Keep java version defined in Neo4j-OGM; otherwise, integration tests are failing because of kotlin configuration (jvmTarget).