### PR TITLE
Remove BND Feature to autogen JPMS declarations

### DIFF
--- a/bnd/neo4j-ogm-embedded-driver.bnd
+++ b/bnd/neo4j-ogm-embedded-driver.bnd
@@ -5,4 +5,4 @@ Import-Package: \
  *
 
 Fragment-Host: \
- org.neo4j.ogm-core
+ neo4j-ogm-core

--- a/bnd/neo4j-ogm-http-driver.bnd
+++ b/bnd/neo4j-ogm-http-driver.bnd
@@ -5,4 +5,4 @@ Import-Package: \
  *
 
 Fragment-Host: \
- org.neo4j.ogm-core
+ neo4j-ogm-core

--- a/delegate.bnd
+++ b/delegate.bnd
@@ -4,5 +4,4 @@ Bundle-License:
 Bundle-SCM:
 Bundle-Vendor:
 
--jpms-module-info:
 -include: ${project.rootdir}/bnd/${project.artifactId}.bnd

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,6 @@
         <bnd.version>5.1.0</bnd.version>
         <directory-maven-plugin.version>0.3.1</directory-maven-plugin.version>
         <maven-jar-plugin.version>3.0.1</maven-jar-plugin.version>
-        <maven-surefire-plugin.version>3.0.0-M4</maven-surefire-plugin.version>
     </properties>
 
     <distributionManagement>
@@ -54,14 +53,6 @@
                         <archive>
                             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
                         </archive>
-                    </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-surefire-plugin</artifactId>
-                    <version>${maven-surefire-plugin.version}</version>
-                    <configuration>
-                        <forkCount>0</forkCount>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
There is a conflict with mavens surefire-plugin. It is not possible to run the surefire and bnds option "-jpms-module-info:" at the same time, at least not without the option "forkCount 0" set. For now, the jpms build option gets disabled. In the future, we have to figure out what is the cause of this problem.

Add missing fragment host declarations.